### PR TITLE
Allow specifying an optional name for import-fn and import-macro

### DIFF
--- a/src/potemkin/namespaces.clj
+++ b/src/potemkin/namespaces.clj
@@ -9,60 +9,68 @@
 (ns potemkin.namespaces
   (:use [clojure pprint]))
 
-(defmacro import-fn 
-  "Given a function in another namespace, defines a function with the same name in the
-   current namespace.  Argument lists, doc-strings, and original line-numbers are preserved."
-  [sym]
-  (let [vr (resolve sym)
-        m (meta vr)
-        n (:name m)
-        arglists (:arglists m)
-        doc (:doc m)
-        protocol (:protocol m)]
-    (when-not vr
-      (throw (IllegalArgumentException. (str "Don't recognize " sym))))
-    (when (:macro m)
-      (throw (IllegalArgumentException. (str "Calling import-fn on a macro: " sym))))
-    `(do
-       (def ~(with-meta n {:protocol protocol}) (deref ~vr))
-       (alter-meta! (var ~n) assoc
-         :doc ~doc
-         :arglists ~(list 'quote arglists)
-         :file ~(:file m)
-         :line ~(:line m))
-       ~vr)))
+(defmacro import-fn
+  "Given a function in another namespace, defines a function with the
+   same name in the current namespace.  Argument lists, doc-strings,
+   and original line-numbers are preserved."
+  ([sym]
+     `(import-fn ~sym nil))
+  ([sym name]
+     (let [vr (resolve sym)
+           m (meta vr)
+           n (or name (:name m))
+           arglists (:arglists m)
+           doc (:doc m)
+           protocol (:protocol m)]
+       (when-not vr
+         (throw (IllegalArgumentException. (str "Don't recognize " sym))))
+       (when (:macro m)
+         (throw (IllegalArgumentException.
+                 (str "Calling import-fn on a macro: " sym))))
+       `(do
+          (def ~(with-meta n {:protocol protocol}) (deref ~vr))
+          (alter-meta! (var ~n) assoc
+                       :doc ~doc
+                       :arglists ~(list 'quote arglists)
+                       :file ~(:file m)
+                       :line ~(:line m))
+          ~vr))))
 
 (defmacro import-macro
-  "Given a macro in another namespace, defines a macro with the same name in the
-   current namespace.  Argument lists, doc-strings, and original line-numbers are preserved."
-  [sym]
-  (let [vr (resolve sym)
-        m (meta vr)
-        n (:name m)
-        arglists (:arglists m)
-        doc (:doc m)]
-    (when-not vr
-      (throw (IllegalArgumentException. (str "Don't recognize " sym))))
-    (when-not (:macro m)
-      (throw (IllegalArgumentException. (str "Calling import-macro on a non-macro: " sym))))
-    `(do
-       (def ~n ~(resolve sym))
-       (alter-meta! (var ~n) assoc
-         :doc ~doc
-         :arglists ~(list 'quote arglists)
-         :file ~(:file m)
-         :line ~(:line m))
-       (.setMacro (var ~n))
-       ~vr)))
+  "Given a macro in another namespace, defines a macro with the same
+   name in the current namespace.  Argument lists, doc-strings, and
+   original line-numbers are preserved."
+  ([sym]
+     `(import-macro ~sym nil))
+  ([sym name]
+     (let [vr (resolve sym)
+           m (meta vr)
+           n (or name (:name m))
+           arglists (:arglists m)
+           doc (:doc m)]
+       (when-not vr
+         (throw (IllegalArgumentException. (str "Don't recognize " sym))))
+       (when-not (:macro m)
+         (throw (IllegalArgumentException.
+                 (str "Calling import-macro on a non-macro: " sym))))
+       `(do
+          (def ~n ~(resolve sym))
+          (alter-meta! (var ~n) assoc
+                       :doc ~doc
+                       :arglists ~(list 'quote arglists)
+                       :file ~(:file m)
+                       :line ~(:line m))
+          (.setMacro (var ~n))
+          ~vr))))
 
-(defmacro import-def 
+(defmacro import-def
   "Given a regular def'd var from another namespace, defined a new var with the
    same name in the current namespace."
   [sym]
   (let [vr (resolve sym)
         m (meta vr)
         n (:name m)
-        n (if (:dynamic m) (with-meta n {:dynamic true}) n) 
+        n (if (:dynamic m) (with-meta n {:dynamic true}) n)
         nspace (:ns m)
         doc (:doc m)]
     (when-not vr
@@ -70,9 +78,9 @@
     `(do
        (def ~n @~vr)
        (alter-meta! (var ~n) assoc
-         :doc ~doc
-         :file ~(:file m)
-         :line ~(:line m))
+                    :doc ~doc
+                    :file ~(:file m)
+                    :line ~(:line m))
        ~vr)))
 
 (defmacro import-vars
@@ -81,23 +89,23 @@
   (let [unravel (fn unravel [x]
                   (if (sequential? x)
                     (->> x
-                      rest
-                      (mapcat unravel)
-                      (map
-                        #(symbol
-                           (str (first x)
-                             (when-let [n (namespace %)]
-                               (str "." n)))
-                           (name %))))
+                         rest
+                         (mapcat unravel)
+                         (map
+                          #(symbol
+                            (str (first x)
+                                 (when-let [n (namespace %)]
+                                   (str "." n)))
+                            (name %))))
                     [x]))
         syms (mapcat unravel syms)]
     `(do
        ~@(map
-           (fn [sym]
-             (let [vr (resolve sym)
-                   m (meta vr)]
-               (cond
-                 (:macro m) `(import-macro ~sym)
-                 (:arglists m) `(import-fn ~sym)
-                 :else `(import-def ~sym))))
-           syms))))
+          (fn [sym]
+            (let [vr (resolve sym)
+                  m (meta vr)]
+              (cond
+               (:macro m) `(import-macro ~sym)
+               (:arglists m) `(import-fn ~sym)
+               :else `(import-def ~sym))))
+          syms))))

--- a/test/potemkin/test/namespaces.clj
+++ b/test/potemkin/test/namespaces.clj
@@ -17,7 +17,9 @@
     [potemkin.test.imports :as i]))
 
 (import-macro i/multi-arity-macro)
+(import-macro i/multi-arity-macro alt-macro-name)
 (import-fn i/multi-arity-fn)
+(import-fn i/multi-arity-fn alt-name)
 (import-fn i/protocol-function)
 
 (defn drop-lines [n s]
@@ -31,11 +33,15 @@
 
 (deftest test-import-macro
   (is (out= (source i/multi-arity-macro) (source multi-arity-macro)))
-  (is (rest-out= (doc i/multi-arity-macro) (doc multi-arity-macro))))
+  (is (rest-out= (doc i/multi-arity-macro) (doc multi-arity-macro)))
+  (is (out= (source i/multi-arity-macro) (source alt-macro-name)))
+  (is (rest-out= (doc i/multi-arity-macro) (doc alt-macro-name))))
 
 (deftest test-import-fn
   (is (out= (source i/multi-arity-fn) (source multi-arity-fn)))
   (is (rest-out= (doc i/multi-arity-fn) (doc multi-arity-fn)))
+  (is (out= (source i/multi-arity-fn) (source alt-name)))
+  (is (rest-out= (doc i/multi-arity-fn) (doc alt-name)))
   (is (rest-out= (doc i/protocol-function) (doc protocol-function))))
 
 


### PR DESCRIPTION
I apologize for the whitespace cleanup in this, if it bothers you I can try to do the PR without it.

Adds the ability to specify an optional name for importing something with `import-fn` and `import-macro`. Which allows using `import-*` for aliasing.
