### PR TITLE
Fixes Testing against different Clojure Versions

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -9,7 +9,7 @@
              :1.4 {:dependencies [[org.clojure/clojure "1.4.0"]]}
              :1.6 {:dependencies [[org.clojure/clojure "1.6.0-master-SNAPSHOT"]]}}
   :warn-on-reflection true
-  :aliases {"all" ["with-profile" "1.2,dev:1.3,dev:dev:1.4,dev:1.6,dev"]}
+  :aliases {"all" ["with-profile" "dev,1.2:dev,1.3:dev,1.4:dev:dev,1.6"]}
   :test-selectors {:default #(not (some #{::benchmark}
                                         (cons (:tag %) (keys %))))
                    :benchmark :benchmark


### PR DESCRIPTION
The current form of the alias "all" has the profile `:dev` overwrite the Clojure version of the profiles `:1.2`, `:1.3`, and so on. This means that the only version really tested is `:dev`'s, being "1.5.1".

This can be demonstrated by adding the line

``` clojure
(println "--- uses clojure:" *clojure-version*)
```

to e.g. "src/potemkin.clj" and running "lein all do clean, test".

This pull request fixes the issue, making the test results more meaningful.
