### PR TITLE
Do an extra sanity check before skipping evaluation of record/type

### DIFF
--- a/src/potemkin/types.clj
+++ b/src/potemkin/types.clj
@@ -247,7 +247,8 @@
 
         classname (with-meta (symbol (str (namespace-munge *ns*) "." name)) (meta name))
 
-        prev-body (@type-bodies classname)]
+        prev-body (when (class? (ns-resolve *ns* name))
+                    (@type-bodies classname))]
     
     (when-not (and prev-body
                 (equivalent?
@@ -275,7 +276,8 @@
   [name & body]
   (let [classname (with-meta (symbol (str (namespace-munge *ns*) "." name)) (meta name))
 
-        prev-body (@type-bodies classname)]
+        prev-body (when (class? (ns-resolve *ns* name))
+                    (@type-bodies classname))]
     
     (when-not (and prev-body
                 (equivalent?


### PR DESCRIPTION
We were running into issues where a namespace didn't load the first time due to errors, and subsequent loads would fail because the class was not mapped in the namespace.  This adds a sanity check for this case and always evaluates the form if the class is not mapped in the namespace.

The easiest way to reproduce the issue is to create a namespace with a defrecord+, evaluate it, remove-ns it, and evaluate the namespace again.

``` clojure
(ns tmp
  (:require potemkin))

(potemkin/defrecord+ Foo [x y])

Foo
```

at the repl:

``` clojure
(require 'tmp)
(remove-ns 'tmp)
(require 'tmp)
```
