### PR TITLE
return a clojure.lang.MapEntry, but only if the key is found in the map

### DIFF
--- a/src/potemkin/collections.clj
+++ b/src/potemkin/collections.clj
@@ -113,14 +113,9 @@
     (contains? (.keySet this) k))
 
   (entryAt [this k]
-    (let [v (.valAt this k nil)]
-      (reify
-        java.util.Map$Entry
-        clojure.lang.IMapEntry
-        (key [_] k)
-        (val [_] v)
-        (getKey [_] k)
-        (getValue [_] v))))
+    (let [v (.valAt this k ::not-found)]
+      (when (not= v ::not-found)
+        (clojure.lang.MapEntry. k v))))
   
   (assoc [this k v]
     (potemkin.collections/assoc* this k v))


### PR DESCRIPTION
I found two slight differences in behavior for clojure's maps versus for maps created with AbstractMap.

First, clojure's maps return a clojure.lang.MapEntry, whereas AbstractMap returns a reified class that's pretty similar to what MapEntry is, which isn't a huge deal, but since there's no toString for it, it ends up being weird at the repl. I solved that here by just returning a clojure.lang.MapEntry, but another solution would be to just define a toString.

Second, if the key doesn't exist in a map, then find is supposed to return nil, but the definition of entryAt that AbstractMap provides will always return a MapEntry, even if the key wasn't found. I fixed that by using the ::not-found magic value (which is a little lame, but anything more correct than that would have been a bigger diff, and I thought I'd keep this small).
