### PR TITLE
Fix var linking in imports

### DIFF
--- a/src/potemkin/namespaces.clj
+++ b/src/potemkin/namespaces.clj
@@ -5,7 +5,7 @@
   [src dst]
   (add-watch src dst
     (fn [_ src old new]
-      (alter-var-root dst (constantly src))
+      (alter-var-root dst (constantly @src))
       (alter-meta! dst merge (dissoc (meta src) :name)))))
 
 (defmacro import-fn
@@ -25,7 +25,7 @@
        (when (:macro m)
          (throw (IllegalArgumentException.
                   (str "Calling import-fn on a macro: " sym))))
-       
+
        `(do
           (def ~(with-meta n {:protocol protocol}) (deref ~vr))
           (alter-meta! (var ~n) merge (dissoc (meta ~vr) :name))

--- a/test/potemkin/imports_test.clj
+++ b/test/potemkin/imports_test.clj
@@ -18,3 +18,5 @@
   {:inline (fn [x] x)}
   [x]
   x)
+
+(def some-value 1)

--- a/test/potemkin/namespaces_test.clj
+++ b/test/potemkin/namespaces_test.clj
@@ -14,6 +14,7 @@
 (import-fn i/multi-arity-fn alt-name)
 (import-fn i/protocol-function)
 (import-fn i/inlined-fn)
+(import-def i/some-value)
 
 (defn drop-lines [n s]
   (->> s str/split-lines (drop n) (interpose "\n") (apply str)))
@@ -39,4 +40,7 @@
   (is (rest-out= (doc i/multi-arity-fn) (doc alt-name)))
   (is (rest-out= (doc i/protocol-function) (doc protocol-function))))
 
-
+(deftest test-points-to-the-value-after-reload
+  (is (= 1 some-value))
+  (require 'potemkin.imports-test :reload)
+  (is (= 1 some-value)))


### PR DESCRIPTION
When an original var is redefined, imported var should point to the new
value of the var, not the var itself.
