### PR TITLE
make condp-case actually throw on no matching clause

### DIFF
--- a/src/potemkin/utils.clj
+++ b/src/potemkin/utils.clj
@@ -76,7 +76,7 @@
                    ~expr)))
              (apply concat))
          :else
-         ~(when-not (even? (count cases))
+         ~(if-not (even? (count cases))
             `(throw (IllegalArgumentException. (str "no matching clause for " (pr-str val##))))
             (last cases))))))
 


### PR DESCRIPTION
Found this typo while linting potemkin with the eastwood linter.
