### PR TITLE
AOT with Java 6

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -15,4 +15,5 @@
                    :all (constantly true)}
   :java-source-paths ["src"]
   :jvm-opts ^:replace ["-server"]
+  :javac-options ["-source" "1.6" "-target" "1.6"]
   :repositories {"sonatype-oss-public" "https://oss.sonatype.org/content/groups/public/"})


### PR DESCRIPTION
This PR ensures that the sole AOT-compiled class is compatible with Java 6.

The current version causes the following:

**project.clj**

``` clojure
(defproject tester "0.1.0-SNAPSHOT"
  :description "FIXME: write description"
  :url "http://example.com/FIXME"
  :license {:name "Eclipse Public License"
            :url "http://www.eclipse.org/legal/epl-v10.html"}
  :dependencies [[org.clojure/clojure "1.6.0"]
                 [potemkin "0.3.9"]]
  :aot [tester.core])
```

**src/tester/core.clj**

``` clojure
(ns tester.core
  (:import potemkin.LazyMapEntry))

(def x (LazyMapEntry. {} :x))
```

**Command Line (Java 7)**

``` bash
$ lein version
Leiningen 2.5.0 on Java 1.7.0_67 Java HotSpot(TM) 64-Bit Server VM

$ lein jar
Compiling tester.core
Created /git/github/tester/target/tester-0.1.0-SNAPSHOT.jar
```

**Command Line (Java 6)**

``` bash
$ JAVA_HOME=/System/Library/Frameworks/JavaVM.framework/Versions/1.6.0/Home lein version 
Leiningen 2.5.0 on Java 1.6.0_65 Java HotSpot(TM) 64-Bit Server VM

$ JAVA_HOME=/System/Library/Frameworks/JavaVM.framework/Versions/1.6.0/Home lein jar
Retrieving potemkin/potemkin/0.3.9/potemkin-0.3.9.pom from clojars
Retrieving potemkin/potemkin/0.3.9/potemkin-0.3.9.jar from clojars
Compiling tester.core
java.lang.UnsupportedClassVersionError: potemkin/LazyMapEntry : Unsupported major.minor version 51.0, compiling:(core.clj:1:1)
        at clojure.lang.Compiler$InvokeExpr.eval(Compiler.java:3558)
        at clojure.lang.Compiler.compile1(Compiler.java:7226)
        at clojure.lang.Compiler.compile1(Compiler.java:7216)
        at clojure.lang.Compiler.compile(Compiler.java:7292)
```
