### PR TITLE
Fix bug in AbstractMap/entryAt

### DIFF
--- a/src/potemkin/collections.clj
+++ b/src/potemkin/collections.clj
@@ -143,7 +143,7 @@
 
   (entryAt [this k]
     (when (contains? (.keySet this) k)
-      (potemkin.LazyMapEntry this k)))
+      (potemkin.LazyMapEntry. this k)))
 
   (assoc [this k v]
     (potemkin.collections/assoc* this k v))

--- a/test/potemkin/collections_test.clj
+++ b/test/potemkin/collections_test.clj
@@ -37,14 +37,18 @@
     (is (= (::meta-key (meta (with-meta m {::meta-key "value"})))
            "value")))
   (test-basic-map-functionality (->SimpleDerivedMap))
-  (test-basic-map-functionality (simple-map {} {})))
+  (test-basic-map-functionality (simple-map {} {}))
+  (is (= [:one "two"] (find (->SimpleMap {:one "two" :three "four"} {}) :one))))
 
 (deftest test-derived-map
   (let [m (->DerivedMap "AbC")]
     (is (= {:string "AbC" :lower "abc" :upper "ABC"} m))
     (is (= {:lower "abc" :upper "ABC"} (dissoc m :string)))
     (is (= {:string "foo" :lower "abc" :upper "ABC" :bar "baz"}
-          (assoc m :string "foo" :bar "baz")))))
+          (assoc m :string "foo" :bar "baz")))
+    (is (= #{:lower :upper :string} (-> m keys set)))
+    (is (= [:lower "abc"] (find m :lower)))
+    (is (= {:lower "abc" :upper "ABC"} (select-keys m [:lower :upper])))))
 
 (def-map-type LazyMap [m]
   (get [_ k default-value]


### PR DESCRIPTION
Previously, this would throw the exception `java.lang.Class cannot be cast to clojure.lang.IFn.` I've added a couple of tests which I used to reproduce the bug, but I'm also taking a crack at augmenting collection-check with test for `find` and `select-keys`.