### PR TITLE
Clojure maps are iterable

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -3,7 +3,7 @@
   :description "Some useful facades."
   :dependencies [[clj-tuple "0.2.1"]
                  [riddley "0.1.7"]]
-  :profiles {:dev {:dependencies [[org.clojure/clojure "1.7.0-alpha5"]
+  :profiles {:dev {:dependencies [[org.clojure/clojure "1.7.0-RC1"]
                                   [criterium "0.4.3"]
                                   [collection-check "0.1.5"]]}}
   :global-vars {*warn-on-reflection* true}

--- a/src/potemkin/collections.clj
+++ b/src/potemkin/collections.clj
@@ -176,6 +176,10 @@
   (entrySet [this]
     (->> this seq set))
 
+  java.util.Iterator
+  (iterator [this]
+    (clojure.lang.SeqIterator. this))
+
   clojure.lang.IPersistentMap
   (assocEx [this k v]
     (if (contains? this k)


### PR DESCRIPTION
Potemkin maps claim to be Iterable (because they implement clojure.lang.IPersistentMap, which is Iterable), but they don't actually have an implementation of `.iterator`. I've added a simple one, it seems to work, I think.

I came across this by way of https://github.com/dakrone/clj-http/issues/266