### PR TITLE
memoize returns nil on first call

### DIFF
--- a/src/potemkin/utils.clj
+++ b/src/potemkin/utils.clj
@@ -99,7 +99,7 @@
        (if-not (nil? v#)
          (re-nil v#)
          (let [v# (de-nil (~f ~@args))]
-           (or (.putIfAbsent ~m k# v#) v#))))))
+           (re-nil (or (.putIfAbsent ~m k# v#) v#)))))))
 
 (defn fast-memoize
   "A version of `memoize` which has equivalent behavior, but is faster."

--- a/test/potemkin/utils_test.clj
+++ b/test/potemkin/utils_test.clj
@@ -15,6 +15,18 @@
 (deftest test-try*
   )
 
+(deftest fast-memoize-test
+  (testing "returns nil on first call"
+    (let [f (fn [x] nil)
+          f' (fast-memoize f)]
+      (is (nil? (f' 1)))))
+
+  (testing "memoizes"
+    (let [f' (fast-memoize +)]
+      (is (= 5 (f' 2 3)))
+      (is (= 5 (f' 2 3)))
+      (is (= 6 (f' 2 3 1))))))
+
 (deftest ^:benchmark benchmark-fast-memoize
   (let [f (memoize +)
         f' (fast-memoize +)]


### PR DESCRIPTION
if the first call to a memoized fn results in `nil`, the result should
be `nil` instead of `::nil`
