### PR TITLE
Clearer failure when trying to import nonexistent var

### DIFF
--- a/src/potemkin/namespaces.clj
+++ b/src/potemkin/namespaces.clj
@@ -96,6 +96,7 @@
             (let [vr (resolve sym)
                   m (meta vr)]
               (cond
+               (nil? vr) `(throw (ex-info (format "`%s` does not exist" '~sym) {}))
                (:macro m) `(import-macro ~sym)
                (:arglists m) `(import-fn ~sym)
                :else `(import-def ~sym))))

--- a/test/potemkin/namespaces_test.clj
+++ b/test/potemkin/namespaces_test.clj
@@ -16,6 +16,7 @@
 (import-fn i/inlined-fn)
 (import-def i/some-value)
 
+
 (defn drop-lines [n s]
   (->> s str/split-lines (drop n) (interpose "\n") (apply str)))
 
@@ -44,3 +45,10 @@
   (is (= 1 some-value))
   (require 'potemkin.imports-test :reload)
   (is (= 1 some-value)))
+
+(deftest import-vars-throws-if-missing-var
+  (try
+    (import-vars [clojure.set union onion-misspelled])
+    (is false "`import-vars` should have thrown an exception")
+  (catch Exception ex
+    (is "`clojure.set/onion-misspelled` does not exist" (.getMessage ex)))))


### PR DESCRIPTION
In 0.4.3, if you try something like `(import-vars [clojure.set misspelling-of-union])`, the error message is:

```
NullPointerException   clojure.core/with-meta--4369 (core.clj:218)
```

... which is not so helpful. This PR converts it to:

```
ExceptionInfo `clojure.set/misspelling-of-union` does not exist  clojure.core/ex-info (core.clj:4616)
```

Notes:
1. This will only warn of the first missing var.
2. I could have had it warn at macroexpansion time, but I had the macro actually generate `throw` code. There's probably no good reason for that - you get the right line numbers in either case.

