### PR TITLE
Fix def-map-type map equality with java.util.Maps

### DIFF
--- a/src/potemkin/collections.clj
+++ b/src/potemkin/collections.clj
@@ -62,7 +62,8 @@
   clojure.lang.IPersistentCollection
 
   (equiv [this x]
-    (and (map? x) (= x (into {} this))))
+    (and (or (instance? java.util.Map x) (map? x))
+         (= x (into {} this))))
 
   (cons [this o]
     (if (map? o)
@@ -125,7 +126,7 @@
   (equals [this x]
     (or (identical? this x)
       (and
-        (map? x)
+        (or (instance? java.util.Map x) (map? x))
         (= x (into {} this)))))
 
   (toString [this]

--- a/test/potemkin/collections_test.clj
+++ b/test/potemkin/collections_test.clj
@@ -21,6 +21,9 @@
     (dissoc [_ k] (simple-map (dissoc m k) mta))
     (keys [_] (keys m))))
 
+(deftest test-simple-map-equiv
+  (is (= (java.util.HashMap.) (simple-map {} {}))))
+
 (def-derived-map SimpleDerivedMap [])
 
 (def-derived-map DerivedMap [^String s]


### PR DESCRIPTION
`map?` predicate only checks for `clojure.lang.IPersistentMap`