### PR TITLE
Fixes NPE in hashcode with empty keys (Issue 52)

### DIFF
--- a/src/potemkin/collections.clj
+++ b/src/potemkin/collections.clj
@@ -119,7 +119,8 @@
   (hashCode [this]
     (reduce
       (fn [acc [k v]]
-        (unchecked-add acc (bit-xor (.hashCode k) (.hashCode v))))
+        (unchecked-add acc (bit-xor (clojure.lang.Util/hash k)
+                                    (clojure.lang.Util/hash v))))
       0
       (seq this)))
 


### PR DESCRIPTION
Several alternatives were tried: if you put the whole unchecked-add if
an `(if (and k v) (unchecked-add ...) 0)` then you get a hashvalue of
0 when there is only one key and a missing value as the key isn't
hashed. If you `(unchecked-add acc (bit-xor (.hashCode (or k 0)) ..`
then you end up with reflection warnings.