### PR TITLE
Fix walk function for record type

### DIFF
--- a/src/potemkin/walk.clj
+++ b/src/potemkin/walk.clj
@@ -9,6 +9,8 @@
             (list? form) (outer (apply list (map inner form)))
             (instance? clojure.lang.IMapEntry form) (outer (vec (map inner form)))
             (seq? form) (outer (doall (map inner form)))
+            (instance? clojure.lang.IRecord form)
+              (outer (reduce (fn [r x] (conj r (inner x))) form form))
             (coll? form) (outer (into (empty form) (map inner form)))
             :else (outer form))]
     (if (instance? clojure.lang.IObj x)


### PR DESCRIPTION
There's a problem when `walk` function is run on a record type, like this:
```clojure
user=> (require '[potemkin.walk])
nil
user=> (defrecord R1 [a b c])
user.R1
user=> (potemkin.walk/prewalk identity [(R1. 1 2 3)])

UnsupportedOperationException Can't create empty: user.R1  user.R1 (form-init2719416585225395373.clj:1)
```

This happens, 'cause https://github.com/ztellman/potemkin/blob/2473a2bf056f06b03de2e47e4708f28d8a445f38/src/potemkin/walk.clj#L12 the `(coll? form)` check for record returns true, and it in order tries to compose an empty instance of it (`(empty form)`).

The following is solved in standard `walk`: https://github.com/clojure/clojure/blob/2224dbad5534ff23d3653b07d9dc0a60ba076dd7/src/clj/clojure/walk.clj#L47

So, in this PR I've copied this line to make it work:
```clojure
user=> (require '[potemkin.walk])
nil
user=> (defrecord R1 [a b c])
user.R1
user=> (potemkin.walk/prewalk identity [(R1. 1 2 3)])
[#user.R1{:a 1, :b 2, :c 3}]
user=> 
```