### PR TITLE
Allow clojure.lang.IFn/applyTo to be overridden in deftype+

### DIFF
--- a/src/potemkin/collections.clj
+++ b/src/potemkin/collections.clj
@@ -43,7 +43,7 @@
                 ~(throw-arity n)))
            (range 0 21))
 
-       (applyTo [this## args##]
+       (~'applyTo [this## args##]
          (let [cnt# (count args##)]
            (case cnt#
              ~@(mapcat


### PR DESCRIPTION
Since the current macro uses a plain symbol, this gets expanded by the backtick to 'potemkin.collections/applyTo. This breaks the merging of the potemkin and user implementations, leading to an error because two "applyTo" implementations are present. This fixes that by preventing the backtick to qualify the symbol.